### PR TITLE
Update michelf/php-markdown dependency version to fix PHP 7.4 compatibility issues regarding deprecated string offset syntax

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   ],
   "require": {
     "craftcms/cms": "^3.0.0",
-    "michelf/php-markdown": "^1.8",
+    "michelf/php-markdown": "^1.9",
     "michelf/php-smartypants": "^1.8"
   },
   "autoload": {


### PR DESCRIPTION
The 1.9.0 version of michelf/php-markdown fixes the string offset syntax, verifiable from their Version History notes: https://packagist.org/packages/michelf/php-markdown . But this package is requiring 1.8.x, so this package's highest supported PHP version is 7.3. Updating this dependency should allow PHP 7.4 compatibility and to the best of my research not introduce any issues.